### PR TITLE
Adding the opencamlib submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "libarea"]
 	path = libarea
 	url = git://github.com/Heeks/libarea.git
+[submodule "opencamlib"]
+	path = opencamlib
+	url = git://github.com/aewallin/opencamlib.git


### PR DESCRIPTION
aewallin is the maintainer of opencamlib and has recently migrated it to github. Adding the library as a submodule allows all of the dependent repos for heekscnc to be cloned with a recursive command
