### PR TITLE
Tapping fixes:

### DIFF
--- a/src/CTool.cpp
+++ b/src/CTool.cpp
@@ -1083,7 +1083,7 @@ void CToolParams::ReadParametersFromXMLElement(TiXmlElement* pElem)
 	}
 	if (pElem->Attribute("direction")) pElem->Attribute("direction", &m_direction);
 	if (pElem->Attribute("pitch")) pElem->Attribute("pitch", &m_pitch);
-	if (pElem->Attribute("drag_distance")) pElem->Attribute("pitch", &m_drag_knife_distance);
+	if (pElem->Attribute("drag_distance")) pElem->Attribute("drag_distance", &m_drag_knife_distance);
 }
 
 CTool::~CTool()

--- a/src/CTool.h
+++ b/src/CTool.h
@@ -55,6 +55,7 @@ public:
 		types_list.push_back( ToolTypeDescription_t( eToolLengthSwitch, wxString(_("Tool Length Switch")) ));
 		types_list.push_back( ToolTypeDescription_t( eEngravingTool, wxString(_("Engraving Tool")) ));
 		types_list.push_back( ToolTypeDescription_t( eDragKnife, wxString(_("Drag Knife")) ));
+		types_list.push_back( ToolTypeDescription_t( eTapTool, wxString(_("Tap Tool")) ));
 		return(types_list);
 	} // End GetToolTypesList() method
 

--- a/src/Drilling.cpp
+++ b/src/Drilling.cpp
@@ -383,10 +383,10 @@ void CDrilling::glCommands(bool select, bool marked, bool no_color)
 
 		if (m_tool_number > 0)
 		{
-			HeeksObj* Tool = heeksCAD->GetIDObject( ToolType, m_tool_number );
+			CTool *Tool = (CTool *) CTool::Find( m_tool_number );
 			if (Tool != NULL)
 			{
-                		l_dHoleDiameter = ((CTool *) Tool)->m_params.m_diameter;
+				l_dHoleDiameter = Tool->m_params.m_diameter;
 			} // End if - then
 		} // End if - then
 

--- a/src/Operations.cpp
+++ b/src/Operations.cpp
@@ -94,9 +94,9 @@ class SetAllActive: public Tool{
 			if(COperations::IsAnOperation(object->GetType()))
 			{
 				((COp*)object)->m_active = true;
-				heeksCAD->Changed();
 			}
 		}
+		heeksCAD->Changed();
 	}
 	wxString BitmapPath(){ return _T("setactive");}
 };
@@ -113,9 +113,9 @@ class SetAllInactive: public Tool{
 			if(COperations::IsAnOperation(object->GetType()))
 			{
 				((COp*)object)->m_active = false;
-				heeksCAD->Changed();
 			}
 		}
+		heeksCAD->Changed();
 	}
 	wxString BitmapPath(){ return _T("setinactive");}
 };

--- a/src/Tapping.cpp
+++ b/src/Tapping.cpp
@@ -166,11 +166,11 @@ Python CTapping::AppendTextToProgram( CMachineState *pMachineState )
 
 	if (m_tool_number > 0)
 	  {
-	    HeeksObj* Tool = heeksCAD->GetIDObject( ToolType, m_tool_number );
+            CTool *Tool = (CTool *) CTool::Find( m_tool_number );
 	    if (Tool != NULL)
 	      {
-		pitch = ((CTool *) Tool)->m_params.m_pitch;
-		direction = ((CTool *) Tool)->m_params.m_direction;
+		pitch = Tool->m_params.m_pitch;
+		direction = Tool->m_params.m_direction;
 	      } // End if - then
 	  } // End if - then
 
@@ -320,10 +320,10 @@ void CTapping::glCommands(bool select, bool marked, bool no_color)
 
 		if (m_tool_number > 0)
 		{
-			HeeksObj* Tool = heeksCAD->GetIDObject( ToolType, m_tool_number );
+			CTool *Tool = (CTool *) CTool::Find( m_tool_number );
 			if (Tool != NULL)
 			{
-                		l_dHoleDiameter = ((CTool *) Tool)->m_params.m_diameter;
+				l_dHoleDiameter = Tool->m_params.m_diameter;
 			} // End if - then
 		} // End if - then
 


### PR DESCRIPTION
  Type dropdown box for tap tool was not filled in.
  Fix copy-and-paste error confusing drag-knife with tap tool.
  Tapping pitch was not being sent to post-processor. Use correct call to find the tool. The same incorrect call was fixed in a couple of other places.
